### PR TITLE
fix searchVCF

### DIFF
--- a/biomine/parsers/exacparser.py
+++ b/biomine/parsers/exacparser.py
@@ -551,17 +551,16 @@ class exacparser(object):
 		entries = {}
 		with pysam.VariantFile( vcf , "r" ) as vf:
 			for var in self.variants:
-				entries[var.genomicVar()] = 1
 				here = str( var.chromosome ) + ':' + str( var.start ) + '-' + str( var.stop )
 				for hit in vf.fetch( region = here ):
 					for i in range( 0 , len( hit.alts ) ):
 						evar = variant( chromosome = hit.contig , \
-										start = hit.start , \
+										start = hit.start + 1 , \
 										dbsnp = hit.id , \
 										reference = hit.alleles[0] , \
 										alternate = hit.alts[i] , \
 									)
 						if var.sameGenomicVariant( evar ):
-							entries[var.genomicVar()] =  hit.info["AF"]
+							entries[var.genomicVar()] =  hit.info["AF"][i]
 		return entries
 

--- a/biomine/parsers/exacparser.py
+++ b/biomine/parsers/exacparser.py
@@ -552,7 +552,7 @@ class exacparser(object):
 		with pysam.VariantFile( vcf , "r" ) as vf:
 			for var in self.variants:
 				entries[var.genomicVar()] = 1
-				here = ':'.join( [ str( var.chromosome ) , str( var.start ) , str( var.stop ) ] )
+				here = str( var.chromosome ) + ':' + str( var.start ) + '-' + str( var.stop )
 				for hit in vf.fetch( region = here ):
 					for i in range( 0 , len( hit.alts ) ):
 						evar = variant( chromosome = hit.contig , \
@@ -563,4 +563,5 @@ class exacparser(object):
 									)
 						if var.sameGenomicVariant( evar ):
 							entries[var.genomicVar()] =  hit.info["AF"]
+		return entries
 


### PR DESCRIPTION
1. The region should be like `chr:start-end` rather than `chr:start:end`. The example in pysam doc has typo and misleading, I just made a PR to fix that example.

2. The `entries ` should be returned.